### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/opencitationsnet/core/resource.py
+++ b/opencitationsnet/core/resource.py
@@ -51,7 +51,7 @@ class JournalArticle(object):
     def identifiers(self):
         ret = []
         if self.prism_doi:
-            ret.append(('DOI', self.prism_doi, 'http://dx.doi.org/%s' % self.prism_doi))
+            ret.append(('DOI', self.prism_doi, 'https://doi.org/%s' % self.prism_doi))
         if self.fabio_hasPubMedId:
             ret.append(('PMID', self.fabio_hasPubMedId, 'http://www.ncbi.nlm.nih.gov/pubmed/%s' % self.fabio_hasPubMedId))
         if self.fabio_hasPubMedCentralId:


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the code that generates new DOI links.

Cheers!